### PR TITLE
increase the scope of createTgz & javaRuntimeVersion

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.15

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,6 +5,6 @@ resolvers += Resolver.url(
   "sbt-plugin-releases",
   url("https://dl.bintray.com/sbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.4.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "0.9.0")

--- a/src/main/scala/uk/gov/hmrc/sbtdistributables/SbtDistributablesPlugin.scala
+++ b/src/main/scala/uk/gov/hmrc/sbtdistributables/SbtDistributablesPlugin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 HM Revenue & Customs
+ * Copyright 2017 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ object SbtDistributablesPlugin extends AutoPlugin {
     publishLocal <<= publishLocal dependsOn distTgzTask
   )
 
-  private def createTgz(targetDir: File, artifactName: String, version: String, javaRuntimeVersion: String, extraFiles: Seq[File]): File = {
+  def createTgz(targetDir: File, artifactName: String, version: String, javaRuntimeVersion: String, extraFiles: Seq[File]): File = {
     val externalTgzFiles = extraTgzFiles(javaRuntimeVersion)
 
     val zip = targetDir / s"$artifactName-$version.zip"
@@ -144,7 +144,7 @@ object SbtDistributablesPlugin extends AutoPlugin {
     Array(("system.properties", s"java.runtime.version=$javaRuntimeVersion", None))
   }
 
-  private def javaRuntimeVersion(scalacOptions: Seq[String]): String = {
+  def javaRuntimeVersion(scalacOptions: Seq[String]): String = {
     if (scalacOptions.contains("-target:jvm-1.8")) "1.8" else "1.7"
   }
 

--- a/src/main/scala/uk/gov/hmrc/sbtdistributables/SbtDistributablesPlugin.scala
+++ b/src/main/scala/uk/gov/hmrc/sbtdistributables/SbtDistributablesPlugin.scala
@@ -52,9 +52,9 @@ object SbtDistributablesPlugin extends AutoPlugin {
       (art: Artifact) => art.copy(`type` = "zip", extension = "tgz")
     },
 
-    publishTgz <<= (target, normalizedName, version) map {
+    publishTgz := ((target, normalizedName, version) map {
       (targetDir, id, version) => targetDir / "universal" / s"$id-$version.tgz"
-    },
+    }).value,
 
     publishArtifact in(Test, packageDoc) := false,
     publishArtifact in(Test, packageSrc) := false,
@@ -63,8 +63,8 @@ object SbtDistributablesPlugin extends AutoPlugin {
     publishArtifact in(Compile, packageSrc) := false,
     publishArtifact in(Compile, packageBin) := true,
 
-    distTgzTask <<= distTgzTask dependsOn distZip,
-    publishLocal <<= publishLocal dependsOn distTgzTask
+    distTgzTask := (distTgzTask dependsOn distZip).value,
+    publishLocal := (publishLocal dependsOn distTgzTask).value
   )
 
   def createTgz(targetDir: File, artifactName: String, version: String, javaRuntimeVersion: String, extraFiles: Seq[File]): File = {


### PR DESCRIPTION
This will allow users to over the name of the distributable